### PR TITLE
check if there's a `data` element in result

### DIFF
--- a/sentineloneapi/client.py
+++ b/sentineloneapi/client.py
@@ -70,10 +70,11 @@ class Client:
             else:
                 raise exceptions.UnhandledRequestType(method)
             rj = r.json()
-            if isinstance(rj['data'], list):
-                data.extend(rj['data'])
-            else:
-                data.append(rj['data'])
+            if 'data' in rj:
+                if isinstance(rj['data'], list):
+                    data.extend(rj['data'])
+                else:
+                    data.append(rj['data'])
             errors.extend(rj.get('errors', []))
             self.logger.debug(f'{endpoint} > {r.status_code} {r.reason}')
             self.logger.debug(f'{endpoint} > {rj}')


### PR DESCRIPTION
pretty self explanatory. I had a response come back without data in it  (auth failure), so this threw a KeyError. I've seen it as well when doing DV and powerqueries where the syntax is incorrect. 